### PR TITLE
Change the filename of recordings

### DIFF
--- a/audio-recorder.js
+++ b/audio-recorder.js
@@ -111,7 +111,7 @@ exports.AudioRecorder =  class AudioRecorder extends EventEmitter {
             console.log(`Recorder ${this.index} started`)
             console.log(`Recorder ${this.index} was ${this.active} active`)
 
-            let filename = path.join(this.workspacePath, `ODAS_${id}_${new Date().toLocaleString()}_${this.suffix}.wav`)
+            let filename = path.join(this.workspacePath, `ODAS_${id}_${new Date().toISOString()}_${this.suffix}.wav`)
             this.path = filename
 
             try {


### PR DESCRIPTION
The locale format of dates for me (and in #7) contains `/`s, which caused the writer to attempt to write a file in subdirectories that don't exist.

This just changes the filename to use `.toISOString()` rather than the locale string for the filename of the recordings as it does not have any '/'.